### PR TITLE
Correct composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "natxet/CssMin",
+	"name": "natxet/cssmin",
 	"description": "Minifying CSS",
 	"keywords": ["css","minify"],
 	"homepage": "http://code.google.com/p/cssmin/",


### PR DESCRIPTION
Corrects naming convention, autoload definition and removes unnecessary properties.

'type' and 'repositories' are unnecessary. 'autoload' should use class map instead of PSR-0. The library doesn't follow PSR-0, instead you will want a class map.

Instead of 'version', please use tags. Using tags allows us to actually use this repo with ease, and removes human-error factor. Tags bring working version constraints and dist support (which removes git dependency when using Composer).
