### PR TITLE
@keyframe name surrounded by quotes not supported by firefox

### DIFF
--- a/src/CssMin.php
+++ b/src/CssMin.php
@@ -4435,6 +4435,10 @@ class CssAtKeyframesStartToken extends aCssAtBlockStartToken
 	 */
 	public function __toString()
 	{
+		if ($this->AtRuleName === "-moz-keyframes")
+		{
+			return "@-moz-keyframes " . $this->Name . " {";
+		}
 		return "@" . $this->AtRuleName . " \"" . $this->Name . "\"{";
 	}
 }


### PR DESCRIPTION
@keyframe are not working in firefox because cssmin add quotes around keyframe name.

I applied this patch : 
https://code.google.com/p/cssmin/issues/attachmentText?id=48&aid=480002000&name=cssmin-3.0.1-no-quotes-moz-keyframes.patch&token=v7vn-GUo3fimMY45GqDPlgjeOZI%3A1371226184202

It fix this issue : https://code.google.com/p/cssmin/issues/detail?id=48
