### PR TITLE
Replace deprecated PREG_REPLACE_EVAL modifier with preg_replace_callback()

### DIFF
--- a/src/CssMin.php
+++ b/src/CssMin.php
@@ -2763,13 +2763,7 @@ class CssConvertNamedColorsMinifierPlugin extends aCssMinifierPlugin
 	 */
 	private $reMatch = null;
 	/**
-	 * Regular expression replacing the value.
-	 *
-	 * @var string
-	 */
-	private $reReplace = "\"\${1}\" . \$this->transformation[strtolower(\"\${2}\")] . \"\${3}\"";
-	/**
-	 * Transformation table used by the {@link CssConvertNamedColorsMinifierPlugin::$reReplace replace regular expression}.
+	 * Transformation table used by the {@link CssConvertNamedColorsMinifierPlugin::reReplace() replacement method}.
 	 *
 	 * @var array
 	 */
@@ -2915,7 +2909,7 @@ class CssConvertNamedColorsMinifierPlugin extends aCssMinifierPlugin
 	/**
 	 * Overwrites {@link aCssMinifierPlugin::__construct()}.
 	 *
-	 * The constructor will create the {@link CssConvertNamedColorsMinifierPlugin::$reReplace replace regular expression}
+	 * The constructor will create the {@link CssConvertNamedColorsMinifierPlugin::$reMatch replace regular expression}
 	 * based on the {@link CssConvertNamedColorsMinifierPlugin::$transformation transformation table}.
 	 *
 	 * @param CssMinifier $minifier The CssMinifier object of this plugin.
@@ -2924,7 +2918,7 @@ class CssConvertNamedColorsMinifierPlugin extends aCssMinifierPlugin
 	 */
 	public function __construct(CssMinifier $minifier, array $configuration = array())
 	{
-		$this->reMatch = "/(^|\s)+(" . implode("|", array_keys($this->transformation)) . ")(\s|$)+/eiS";
+		$this->reMatch = "/(^|\s)+(" . implode("|", array_keys($this->transformation)) . ")(\s|$)+/iS";
 		parent::__construct($minifier, $configuration);
 	}
 	/**
@@ -2944,9 +2938,19 @@ class CssConvertNamedColorsMinifierPlugin extends aCssMinifierPlugin
 		// Declaration value contains a value in the transformation table => regular expression replace
 		elseif (preg_match($this->reMatch, $token->Value))
 		{
-			$token->Value = preg_replace($this->reMatch, $this->reReplace, $token->Value);
+			$token->Value = preg_replace_callback($this->reMatch, array($this, 'reReplace'), $token->Value);
 		}
 		return false;
+	}
+	/**
+	 * Callback for replacement value.
+	 *
+	 * @param array $match
+	 * @return string
+	 */
+	private function reReplace($match)
+	{
+		return $match[1] . $this->transformation[strtolower($match[2])] . $match[3];
 	}
 	/**
 	 * Implements {@link aMinifierPlugin::getTriggerTokens()}
@@ -3543,13 +3547,7 @@ class CssConvertFontWeightMinifierPlugin extends aCssMinifierPlugin
 	 */
 	private $reMatch = null;
 	/**
-	 * Regular expression replace the value.
-	 *
-	 * @var string
-	 */
-	private $reReplace = "\"\${1}\" . \$this->transformation[\"\${2}\"] . \"\${3}\"";
-	/**
-	 * Transformation table used by the {@link CssConvertFontWeightMinifierPlugin::$reReplace replace regular expression}.
+	 * Transformation table used by the {@link CssConvertFontWeightMinifierPlugin::reReplace() replacement method}.
 	 *
 	 * @var array
 	 */
@@ -3561,7 +3559,7 @@ class CssConvertFontWeightMinifierPlugin extends aCssMinifierPlugin
 	/**
 	 * Overwrites {@link aCssMinifierPlugin::__construct()}.
 	 *
-	 * The constructor will create the {@link CssConvertFontWeightMinifierPlugin::$reReplace replace regular expression}
+	 * The constructor will create the {@link CssConvertFontWeightMinifierPlugin::$reMatch replace regular expression}
 	 * based on the {@link CssConvertFontWeightMinifierPlugin::$transformation transformation table}.
 	 *
 	 * @param CssMinifier $minifier The CssMinifier object of this plugin.
@@ -3569,7 +3567,7 @@ class CssConvertFontWeightMinifierPlugin extends aCssMinifierPlugin
 	 */
 	public function __construct(CssMinifier $minifier)
 	{
-		$this->reMatch = "/(^|\s)+(" . implode("|", array_keys($this->transformation)). ")(\s|$)+/eiS";
+		$this->reMatch = "/(^|\s)+(" . implode("|", array_keys($this->transformation)). ")(\s|$)+/iS";
 		parent::__construct($minifier);
 	}
 	/**
@@ -3582,9 +3580,19 @@ class CssConvertFontWeightMinifierPlugin extends aCssMinifierPlugin
 	{
 		if (in_array($token->Property, $this->include) && preg_match($this->reMatch, $token->Value, $m))
 		{
-			$token->Value = preg_replace($this->reMatch, $this->reReplace, $token->Value);
+			$token->Value = preg_replace_callback($this->reMatch, array($this, 'reReplace'), $token->Value);
 		}
 		return false;
+	}
+	/**
+	 * Callback for replacement value.
+	 *
+	 * @param array $match
+	 * @return string
+	 */
+	private function reReplace($match)
+	{
+		return $match[1] . $this->transformation[strtolower($match[2])] . $match[3];
 	}
 	/**
 	 * Implements {@link aMinifierPlugin::getTriggerTokens()}


### PR DESCRIPTION
`PREG_REPLACE_EVAL` modifier is deprecated since PHP 5.5.0, this PR resolves this problem by using preg_replace_callback instead.
