### PR TITLE
Add branch-alias to 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
 	},
 	"autoload": {
 		"classmap": ["src/"]
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "3.0-dev"
+		}
 	}
 }


### PR DESCRIPTION
So people can require 3.x@dev.
And perhaps tag a new release, if it fixes 5.5 compat?
