### PR TITLE
Fix parsing @font-face

### DIFF
--- a/src/CssMin.php
+++ b/src/CssMin.php
@@ -4933,7 +4933,7 @@ class CssAtFontFaceParserPlugin extends aCssParserPlugin
 		{
 			$this->parser->pushState("T_AT_FONT_FACE::PREPARE");
 			$this->parser->clearBuffer();
-			return $index + 10;
+			return $index + 10 - 1;
 		}
 		// Start of @font-face declarations
 		elseif ($char === "{" && $state === "T_AT_FONT_FACE::PREPARE")


### PR DESCRIPTION
Let's say we have this initial css code:
```css
@font-face{
        font-family: somefont;
}
body{
        background: #f00;
}
```
Without this patch, `\CssMin::minify` returns
```css
@font-face{background:#f00}
```

With this patch we have
```css
@font-face{font-family:somefont}body{background:#f00}
```