### PR TITLE
Fix @keyframes double quotes

### DIFF
--- a/src/CssMin.php
+++ b/src/CssMin.php
@@ -465,7 +465,7 @@ class CssWhitesmithsFormatter extends aCssFormatter
 			}
 			elseif ($class === "CssAtKeyframesStartToken")
 			{
-				$r[] = $indent . "@keyframes \"" . $token->Name . "\"";
+				$r[] = $indent . "@keyframes " . $token->Name;
 				$r[] = $this->indent . $indent . "{";
 				$level++;
 			}
@@ -1840,7 +1840,7 @@ class CssOtbsFormatter extends aCssFormatter
 			}
 			elseif ($class === "CssAtKeyframesStartToken")
 			{
-				$r[] = $indent . "@keyframes \"" . $token->Name . "\" {";
+				$r[] = $indent . "@keyframes " . $token->Name . " {";
 				$level++;
 			}
 			elseif ($class === "CssAtMediaStartToken")
@@ -4467,7 +4467,7 @@ class CssAtKeyframesStartToken extends aCssAtBlockStartToken
 		{
 			return "@-moz-keyframes " . $this->Name . " {";
 		}
-		return "@" . $this->AtRuleName . " \"" . $this->Name . "\"{";
+		return "@" . $this->AtRuleName . " " . $this->Name . "{";
 	}
 }
 


### PR DESCRIPTION
When minifying, the library adds unnecessary double quotes to the `@keyframes` rule.
Fix https://github.com/natxet/CssMin/issues/16

This commit remove them.

The changes have been tested on __Firefox 40+__, __Safari 8+__, __Chrome 45+__ and __Opera 31+__.