### PR TITLE
RemoveComments: Whitelist comments like copyright

### DIFF
--- a/src/CssMin.php
+++ b/src/CssMin.php
@@ -1345,6 +1345,13 @@ class CssRemoveEmptyAtBlocksMinifierFilter extends aCssMinifierFilter
 class CssRemoveCommentsMinifierFilter extends aCssMinifierFilter
 {
 	/**
+	 * Regular expression whitelisting any important comments to preserve.
+	 *
+	 * @var string
+	 */
+	private $whitelistPattern = '/(^\/\*!|@preserve|copyright|license|author|http:|www\.)/i';
+
+	/**
 	 * Implements {@link aCssMinifierFilter::filter()}.
 	 *
 	 * @param array $tokens Array of objects of type aCssToken
@@ -1357,8 +1364,11 @@ class CssRemoveCommentsMinifierFilter extends aCssMinifierFilter
 		{
 			if (get_class($tokens[$i]) === "CssCommentToken")
 			{
-				$tokens[$i] = null;
-				$r++;
+				if (!preg_match($this->whitelistPattern, $tokens[$i]->Comment))
+				{
+					$tokens[$i] = null;
+					$r++;
+				}
 			}
 		}
 		return $r;

--- a/src/CssMin.php
+++ b/src/CssMin.php
@@ -1349,7 +1349,7 @@ class CssRemoveCommentsMinifierFilter extends aCssMinifierFilter
 	 *
 	 * @var string
 	 */
-	private $whitelistPattern = '/(^\/\*!|@preserve|copyright|license|author|http:|www\.)/i';
+	private $whitelistPattern = '/(^\/\*!|@preserve|copyright|license|author|https?:|www\.)/i';
 
 	/**
 	 * Implements {@link aCssMinifierFilter::filter()}.


### PR DESCRIPTION
In my opinion comments including copyright or license information should not be removed.

The first pattern matches `/*!` which is used by YUI. I've also seen `@preserve` and the rest are obvious.

If you don't think this should change as a default, I could implement it as a new filter. Could this be done via configuration instead? I haven't looked at the library enough to figure it out.