### PR TITLE
Fixed incorrect css parsing when value for url() contains data with parentheses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,0 @@
-.idea
-/vendor
-composer.phar
-composer.lock
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea
+/vendor
+composer.phar
+composer.lock
+.DS_Store

--- a/src/CssMin.php
+++ b/src/CssMin.php
@@ -1662,6 +1662,20 @@ class CssParser
 				}
 			}
 			$buffer .= $c;
+
+			// Fix case when value of url() contains parentheses, for example: url("data: ... ()")
+			if ($this->getState() == 'T_URL' && $c == ')') {
+				$trimmedBuffer = trim($buffer);
+				if (preg_match('@url\((\s+)?".+@', $trimmedBuffer)
+					&& !preg_match('@url\((\s+)?".+"\)@', $trimmedBuffer)
+					|| preg_match('@url\((\s+)?\'.+@', $trimmedBuffer)
+					&& !preg_match('@url\((\s+)?\'.+\'\)@', $trimmedBuffer)
+				) {
+					$p = $c; // Set the parent char
+					continue;
+				}
+			}
+
 			// Extended processing only if the current char is a global trigger char
 			if (strpos($globalTriggerChars, $c) !== false)
 			{


### PR DESCRIPTION
Fixed incorrect parsing for this example: url("data: ... ()")