### PR TITLE
Fix bracket for count() argument

### DIFF
--- a/src/CssMin.php
+++ b/src/CssMin.php
@@ -2409,7 +2409,7 @@ class CssImportImportsMinifierFilter extends aCssMinifierFilter
 									$import[$ii]->MediaTypes = $tokens[$i]->MediaTypes;
 								}
 								// @import at-rule defineds one or more media types; filter out media types not matching with the  parent @import at-rule
-								elseif (count($import[$ii]->MediaTypes > 0))
+								elseif (count($import[$ii]->MediaTypes) > 0)
 								{
 									foreach ($import[$ii]->MediaTypes as $index => $mediaType)
 									{


### PR DESCRIPTION
I found this issue with static code analysis and fixed it blindly (so cannot see the consequences, but before the fix it was obviously unintended).